### PR TITLE
Update README.md to clarify repos.txt format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A utility for transferring multiple GitHub repositories to a new owner (user or 
 
 0. Clone this repository and open up a terminal in the root directory
 1. Install `bash`, `curl`, & `jq` and any dependencies if you don't already have them installed
-2. Replace the contents of `repos.txt` with a newline separated list of repositories to transfer in the following format: `USER/REPO_NAME` (*See 'Preparation' above*)
+2. Replace the contents of `repos.txt` with a newline separated list of repositories to transfer in the following format: `REPO_NAME` (*See 'Preparation' above*)
 3. Set your GitHub Personal Access Token (or password if you insist) as an environment variable named `GITHUB_SECRET`
 4. Execute the program with your username (OWNER) and the name of the new owner (NEWOWNER): `bash bulk_transfer_repos.sh OWNER NEWOWNER` 
 


### PR DESCRIPTION
Using a literal `USER/REPO_NAME` format led to the repo name being included in the `curl` request, which caused in a 404 response from the API, and a bit of head-scratching from me. 

Eventually I figured out that the `OWNER` arg to the bash script was being passed in, and that `repos.txt` was really intended to include _only_ the repo name.